### PR TITLE
Add S3/CloudFront PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-s3.yml
+++ b/.github/workflows/publish-s3.yml
@@ -1,0 +1,52 @@
+name: Publish to S3 PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: eu-central-1
+  AWS_ACCOUNT_ID: "485262375119"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/gh-oidc-role
+          role-session-name: GitHubActions-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload distribution to S3
+        run: |
+          aws s3 sync dist/ s3://wfp-hip-pypi/pypi/data-bridges-client/ \
+            --exclude "*" --include "*.whl" --include "*.tar.gz"
+
+      - name: Regenerate index.html
+        run: |
+          aws s3 ls s3://wfp-hip-pypi/pypi/data-bridges-client/ \
+            | awk -f scripts/render-simple-index.awk > index.html
+          aws s3 cp index.html s3://wfp-hip-pypi/pypi/data-bridges-client/index.html \
+            --content-type "text/html"

--- a/scripts/render-simple-index.awk
+++ b/scripts/render-simple-index.awk
@@ -1,0 +1,18 @@
+#!/usr/bin/awk -f
+#
+# Generate "simple pypi index" from s3 directory listing
+#
+# > aws s3 ls s3://bucket/path/ | ./render-simple-index.awk | tee index.html
+#
+BEGIN {
+   print "<!DOCTYPE html>"
+   print "<html><body>"
+}
+
+/.*\.(whl|gz)$/ {
+  print "  <a href=\"" $4 "\">" $4 "</a></br>"
+}
+
+END {
+    print "</body></html>"
+}


### PR DESCRIPTION
Adds an automated publish pipeline triggered on version tag push (v*).
                                                                                                                                                                 
On tag push:             
  1. Builds the package with python -m build                                                                                                                     
  2. Uploads wheels and sdist to the wfp-hip-pypi S3 bucket via OIDC (no stored credentials)                                                                     
  3. Regenerates the PEP 503 index.html for the package path                                
 
The package is then installable via:
`pip install data-bridges-client --extra-index-url https://d2i4vvypvg40rv.cloudfront.net/pypi/`                                                                                         
                                                                                                                                                                 
Infrastructure (S3 bucket, CloudFront distribution, OIDC role) was provisioned separately via CDK in hip-data-science-tools.

Successfully tested for tag v7.0.0
